### PR TITLE
Add Snowflake-specific implementation of `min_or_max`

### DIFF
--- a/macros/utils/aggregations/_min_or_max.sql
+++ b/macros/utils/aggregations/_min_or_max.sql
@@ -1,20 +1,65 @@
 {% macro _min_or_max(min_or_max, qualified_col) %}
 
+{% if target.type == "snowflake" %}
 {% set aggregation = "min_by" if min_or_max == "min" else "max_by" %}
 {% set qualified_ts_col = "{}.{}".format(
     dbt_activity_schema.appended(), dbt_activity_schema.columns().ts
 ) %}
 
-{# Apply min or max by to the selected column #}
+{# Apply min or max by to the selected column. #}
 {% set aggregated_col %}
-    {{ aggregation }}({{ qualified_col }}, {{ qualified_ts_col }})
+        {{ aggregation }}({{ qualified_col }}, {{ qualified_ts_col }})
 {% endset %}
 
 {# Return output. #}
+{% do return(aggregated_col) %}
+
+{% else %}
+{% set aggregation = "min" if min_or_max == "min" else "max" %}
+{% set column_name = qualified_col.split(".")[-1].strip() %}
+{% set qualified_ts_col = "{}.{}".format(
+    dbt_activity_schema.appended(), dbt_activity_schema.columns().ts
+) %}
+{% set columns = dbt_activity_schema.columns() %}
+
+{# Set type to cast back to after aggregation. #}
+{# TODO: Refactor column abstraction to contain types. #}
+{% if column_name in [columns.ts, columns.activity_repeated_at] %}
+{% set type = dbt.type_timestamp() %}
+{% elif column_name in [columns.activity_occurrence, columns.revenue_impact] %}
+{% set type = dbt.type_numeric() %}
+{% else %} {% set type = dbt.type_string() %}
+{% endif %}
+
+{# Prepend ts column and aggregate. See here for details: https://tinyurl.com/mwfz6xm4 #}
+{% set ts_concatenated_and_aggregated_col %}
+        {{ aggregation }}(
+            {{ dbt.concat([
+                dbt.safe_cast(qualified_ts_col, dbt.type_string()),
+                dbt.safe_cast(qualified_col, dbt.type_string())
+                ]) }}
+            )
+{% endset %}
+
+{# Aggregate ts column before trimming, so it is not required in GROUP BY. #}
+{% set aggregated_ts_col %}
+        {{ aggregation }}( {{ dbt.safe_cast(qualified_ts_col, dbt.type_string()) }} )
+{% endset %}
+
+{# Calculate length of column without prepended & aggregated ts column. #}
+{% set retain_n_rightmost_characters %}
+    {{ dbt.length(ts_concatenated_and_aggregated_col) }} - {{ dbt.length(aggregated_ts_col) }}
+{% endset %}
+
+{# Remove prepended & aggregated ts column. #}
 {% set output %}
-{{ aggregated_col }}
+    {{ dbt.safe_cast(
+        dbt.right(
+            ts_concatenated_and_aggregated_col,
+            retain_n_rightmost_characters
+        ), type) }}
 {% endset %}
 
 {% do return(output) %}
-
+{% endif %}
 {% endmacro %}

--- a/macros/utils/aggregations/_min_or_max.sql
+++ b/macros/utils/aggregations/_min_or_max.sql
@@ -1,54 +1,18 @@
 {% macro _min_or_max(min_or_max, qualified_col) %}
 
-{% set aggregation = "min" if min_or_max == "min" else "max" %}
-{% set column_name = qualified_col.split(".")[-1].strip() %}
-{% set qualified_ts_col = "{}.{}".format(dbt_activity_schema.appended(), dbt_activity_schema.columns().ts )%}
-{% set columns = dbt_activity_schema.columns() %}
+{% set aggregation = "min_by" if min_or_max == "min" else "max_by" %}
+{% set qualified_ts_col = "{}.{}".format(
+    dbt_activity_schema.appended(), dbt_activity_schema.columns().ts
+) %}
 
-
-{# Set type to cast back to after aggregation. #}
-{# TODO: Refactor column abstraction to contain types. #}
-{% if column_name in [
-    columns.ts,
-    columns.activity_repeated_at
-] %}
-    {% set type = dbt.type_timestamp() %}
-{% elif column_name in [
-    columns.activity_occurrence,
-    columns.revenue_impact
-] %}
-    {% set type = dbt.type_numeric() %}
-{% else %}
-    {% set type = dbt.type_string() %}
-{% endif %}
-
-{# Prepend ts column and aggregate. See here for details: https://tinyurl.com/mwfz6xm4 #}
-{% set ts_concatenated_and_aggregated_col %}
-    {{ aggregation }}(
-        {{ dbt.concat([
-            dbt.safe_cast(qualified_ts_col, dbt.type_string()),
-            dbt.safe_cast(qualified_col, dbt.type_string())
-            ]) }}
-        )
+{# Apply min or max by to the selected column #}
+{% set aggregated_col %}
+    {{ aggregation }}({{ qualified_col }}, {{ qualified_ts_col }})
 {% endset %}
 
-{# Aggregate ts column before trimming, so it is not required in GROUP BY. #}
-{% set aggregated_ts_col %}
-    {{ aggregation }}( {{ dbt.safe_cast(qualified_ts_col, dbt.type_string()) }} )
-{% endset %}
-
-{# Calculate length of column without prepended & aggregated ts column. #}
-{% set retain_n_rightmost_characters %}
-{{ dbt.length(ts_concatenated_and_aggregated_col) }} - {{ dbt.length(aggregated_ts_col) }}
-{% endset %}
-
-{# Remove prepended & aggregated ts column. #}
+{# Return output. #}
 {% set output %}
-{{ dbt.safe_cast(
-    dbt.right(
-        ts_concatenated_and_aggregated_col,
-        retain_n_rightmost_characters
-    ), type) }}
+{{ aggregated_col }}
 {% endset %}
 
 {% do return(output) %}


### PR DESCRIPTION
Per #26, the generic implementation of the `_min_or_max` macro does not work correctly on Snowflake, with the root cause being dbt's `safe_cast` using a function in Snowflake with limitations that make it unsuitable for this purpose.

Given that this macro is intended to create the equivalent of Snowflake's `min_by`/`max_by` functions, the work of this PR is to:
- Create a version of the macro that uses Snowflake's functions and achieves the same end.
- Add conditional logic to use the Snowflake-specific macro if on Snowflake, but otherwise default to the current production version.