### PR TITLE
[🐛] Enable parsing of feature json columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,10 @@ dataset.
 - **`included_columns (optional)`** : List [ str ]
 
   List of columns to include for the activity. Setting this overrides the
-  defaults configured by the `default_dataset_columns` project var.
+  defaults configured by the `default_dataset_columns` project var. If a column
+  specified is not identified as any of the columns (or their project-specific
+  aliases) from the Activity Schema spec, the column is assumed to be contained in
+  the corresponding activity's `feature_json` and will be extracted.
 
 - **`additional_join_condition (optional)`** : str
 

--- a/integration_tests/models/first_ever/dataset__first_ever_1.sql
+++ b/integration_tests/models/first_ever/dataset__first_ever_1.sql
@@ -1,7 +1,11 @@
 {{
     dbt_activity_schema.dataset(
         ref("example__activity_stream"),
-        dbt_activity_schema.activity(dbt_activity_schema.all_ever(),"visited page"),
+        dbt_activity_schema.activity(
+            dbt_activity_schema.all_ever(),
+            "visited page",
+            var("dbt_activity_schema").get("included_columns") + ["visited_page"]
+        ),
         [
             dbt_activity_schema.activity(
                 dbt_activity_schema.first_ever(),

--- a/integration_tests/models/first_ever/dataset__first_ever_1.sql
+++ b/integration_tests/models/first_ever/dataset__first_ever_1.sql
@@ -6,7 +6,7 @@
             dbt_activity_schema.activity(
                 dbt_activity_schema.first_ever(),
                 "signed up",
-                ["feature_json", "ts"]
+                ["feature_json", "ts", "signed_up"]
             )
         ]
     )

--- a/integration_tests/models/first_ever/first_ever.yml
+++ b/integration_tests/models/first_ever/first_ever.yml
@@ -3,6 +3,7 @@ version: 2
 models:
 
   - name: dataset__first_ever_1
+    description: dataset used to validate that the `first_ever` relationship is implemented properly. Also selects a parsed json feature from both the primary and appended activity to validate that json parsing works as expected when developers specify columns packed in the `feature_json` in the `included_columns` argument of the `activity` macro.
     tests:
       - dbt_utils.equality:
           compare_model: ref("output__first_ever_1")

--- a/integration_tests/seeds/example__activity_stream.csv
+++ b/integration_tests/seeds/example__activity_stream.csv
@@ -1,55 +1,55 @@
 activity_id,ts,entity_uuid,activity,anonymous_entity_uuid,feature_json,revenue_impact,link,activity_occurrence,activity_repeated_at
-2,2022-01-01 22:10:11,1,visited page,,[{""visited page"": 1}],0,,1,2022-01-28 22:10:11
-3,2022-01-02 22:10:11,1,signed up,,[{""signed up"": 1}],0,,1,2022-01-29 22:10:11
-4,2022-01-03 22:10:11,1,bought something,,[{""bought something"": 1}],100,,1,2022-01-30 22:10:11
-5,2022-01-04 22:10:11,4,visited page,,[{""visited page"": 1}],0,,1,2022-01-31 22:10:11
-6,2022-01-05 22:10:11,4,signed up,,[{""signed up"": 1}],0,,1,2022-02-01 22:10:11
-7,2022-01-06 22:10:11,4,bought something,,[{""bought something"": 1}],100,,1,2022-02-02 22:10:11
-8,2022-01-07 22:10:11,7,visited page,,[{""visited page"": 1}],0,,1,2022-02-03 22:10:11
-9,2022-01-08 22:10:11,7,signed up,,[{""signed up"": 1}],0,,1,2022-02-04 22:10:11
-10,2022-01-09 22:10:11,7,bought something,,[{""bought something"": 1}],100,,1,2022-02-05 22:10:11
-11,2022-01-10 22:10:11,10,visited page,,[{""visited page"": 1}],0,,1,2022-02-06 22:10:11
-12,2022-01-11 22:10:11,10,signed up,,[{""signed up"": 1}],0,,1,2022-02-07 22:10:11
-13,2022-01-12 22:10:11,10,bought something,,[{""bought something"": 1}],100,,1,2022-02-08 22:10:11
-14,2022-01-13 22:10:11,13,visited page,,[{""visited page"": 1}],0,,1,2022-02-09 22:10:11
-15,2022-01-14 22:10:11,13,signed up,,[{""signed up"": 1}],0,,1,2022-02-10 22:10:11
-16,2022-01-15 22:10:11,13,bought something,,[{""bought something"": 1}],100,,1,2022-02-11 22:10:11
-17,2022-01-16 22:10:11,16,visited page,,[{""visited page"": 1}],0,,1,2022-02-12 22:10:11
-18,2022-01-17 22:10:11,16,signed up,,[{""signed up"": 1}],0,,1,2022-02-13 22:10:11
-19,2022-01-18 22:10:11,16,bought something,,[{""bought something"": 1}],100,,1,2022-02-14 22:10:11
-20,2022-01-19 22:10:11,19,visited page,,[{""visited page"": 1}],0,,1,2022-02-15 22:10:11
-21,2022-01-20 22:10:11,19,signed up,,[{""signed up"": 1}],0,,1,2022-02-16 22:10:11
-22,2022-01-21 22:10:11,19,bought something,,[{""bought something"": 1}],100,,1,2022-02-17 22:10:11
-23,2022-01-22 22:10:11,22,visited page,,[{""visited page"": 1}],0,,1,2022-02-18 22:10:11
-24,2022-01-23 22:10:11,22,signed up,,[{""signed up"": 1}],0,,1,2022-02-19 22:10:11
-25,2022-01-24 22:10:11,22,bought something,,[{""bought something"": 1}],100,,1,2022-02-20 22:10:11
-26,2022-01-25 22:10:11,25,visited page,,[{""visited page"": 1}],0,,1,2022-02-21 22:10:11
-27,2022-01-26 22:10:11,25,signed up,,[{""signed up"": 1}],0,,1,2022-02-22 22:10:11
-28,2022-01-27 22:10:11,25,bought something,,[{""bought something"": 1}],100,,1,2022-02-23 22:10:11
-29,2022-01-28 22:10:11,1,visited page,,[{""visited page"": 1}],0,,2,
-30,2022-01-29 22:10:11,1,signed up,,[{""signed up"": 1}],0,,2,
-31,2022-01-30 22:10:11,1,bought something,,[{""bought something"": 1}],100,,2,
-32,2022-01-31 22:10:11,4,visited page,,[{""visited page"": 1}],0,,2,
-33,2022-02-01 22:10:11,4,signed up,,[{""signed up"": 1}],0,,2,
-34,2022-02-02 22:10:11,4,bought something,,[{""bought something"": 1}],100,,2,
-35,2022-02-03 22:10:11,7,visited page,,[{""visited page"": 1}],0,,2,
-36,2022-02-04 22:10:11,7,signed up,,[{""signed up"": 1}],0,,2,
-37,2022-02-05 22:10:11,7,bought something,,[{""bought something"": 1}],100,,2,
-38,2022-02-06 22:10:11,10,visited page,,[{""visited page"": 1}],0,,2,
-39,2022-02-07 22:10:11,10,signed up,,[{""signed up"": 1}],0,,2,
-40,2022-02-08 22:10:11,10,bought something,,[{""bought something"": 1}],100,,2,
-41,2022-02-09 22:10:11,13,visited page,,[{""visited page"": 1}],0,,2,
-42,2022-02-10 22:10:11,13,signed up,,[{""signed up"": 1}],0,,2,
-43,2022-02-11 22:10:11,13,bought something,,[{""bought something"": 1}],100,,2,
-44,2022-02-12 22:10:11,16,visited page,,[{""visited page"": 1}],0,,2,
-45,2022-02-13 22:10:11,16,signed up,,[{""signed up"": 1}],0,,2,
-46,2022-02-14 22:10:11,16,bought something,,[{""bought something"": 1}],100,,2,
-47,2022-02-15 22:10:11,19,visited page,,[{""visited page"": 1}],0,,2,
-48,2022-02-16 22:10:11,19,signed up,,[{""signed up"": 1}],0,,2,
-49,2022-02-17 22:10:11,19,bought something,,[{""bought something"": 1}],100,,2,
-50,2022-02-18 22:10:11,22,visited page,,[{""visited page"": 1}],0,,2,
-51,2022-02-19 22:10:11,22,signed up,,[{""signed up"": 1}],0,,2,
-52,2022-02-20 22:10:11,22,bought something,,[{""bought something"": 1}],100,,2,
-53,2022-02-21 22:10:11,25,visited page,,[{""visited page"": 1}],0,,2,
-54,2022-02-22 22:10:11,25,signed up,,[{""signed up"": 1}],0,,2,
-55,2022-02-23 22:10:11,25,bought something,,[{""bought something"": 1}],100,,2,
+2,2022-01-01 22:10:11,1,visited page,,{"visited_page": 1},0,,1,2022-01-28 22:10:11
+3,2022-01-02 22:10:11,1,signed up,,{"signed_up": 1},0,,1,2022-01-29 22:10:11
+4,2022-01-03 22:10:11,1,bought something,,{"bought_something": 1},100,,1,2022-01-30 22:10:11
+5,2022-01-04 22:10:11,4,visited page,,{"visited_page": 1},0,,1,2022-01-31 22:10:11
+6,2022-01-05 22:10:11,4,signed up,,{"signed_up": 1},0,,1,2022-02-01 22:10:11
+7,2022-01-06 22:10:11,4,bought something,,{"bought_something": 1},100,,1,2022-02-02 22:10:11
+8,2022-01-07 22:10:11,7,visited page,,{"visited_page": 1},0,,1,2022-02-03 22:10:11
+9,2022-01-08 22:10:11,7,signed up,,{"signed_up": 1},0,,1,2022-02-04 22:10:11
+10,2022-01-09 22:10:11,7,bought something,,{"bought_something": 1},100,,1,2022-02-05 22:10:11
+11,2022-01-10 22:10:11,10,visited page,,{"visited_page": 1},0,,1,2022-02-06 22:10:11
+12,2022-01-11 22:10:11,10,signed up,,{"signed_up": 1},0,,1,2022-02-07 22:10:11
+13,2022-01-12 22:10:11,10,bought something,,{"bought_something": 1},100,,1,2022-02-08 22:10:11
+14,2022-01-13 22:10:11,13,visited page,,{"visited_page": 1},0,,1,2022-02-09 22:10:11
+15,2022-01-14 22:10:11,13,signed up,,{"signed_up": 1},0,,1,2022-02-10 22:10:11
+16,2022-01-15 22:10:11,13,bought something,,{"bought_something": 1},100,,1,2022-02-11 22:10:11
+17,2022-01-16 22:10:11,16,visited page,,{"visited_page": 1},0,,1,2022-02-12 22:10:11
+18,2022-01-17 22:10:11,16,signed up,,{"signed_up": 1},0,,1,2022-02-13 22:10:11
+19,2022-01-18 22:10:11,16,bought something,,{"bought_something": 1},100,,1,2022-02-14 22:10:11
+20,2022-01-19 22:10:11,19,visited page,,{"visited_page": 1},0,,1,2022-02-15 22:10:11
+21,2022-01-20 22:10:11,19,signed up,,{"signed_up": 1},0,,1,2022-02-16 22:10:11
+22,2022-01-21 22:10:11,19,bought something,,{"bought_something": 1},100,,1,2022-02-17 22:10:11
+23,2022-01-22 22:10:11,22,visited page,,{"visited_page": 1},0,,1,2022-02-18 22:10:11
+24,2022-01-23 22:10:11,22,signed up,,{"signed_up": 1},0,,1,2022-02-19 22:10:11
+25,2022-01-24 22:10:11,22,bought something,,{"bought_something": 1},100,,1,2022-02-20 22:10:11
+26,2022-01-25 22:10:11,25,visited page,,{"visited_page": 1},0,,1,2022-02-21 22:10:11
+27,2022-01-26 22:10:11,25,signed up,,{"signed_up": 1},0,,1,2022-02-22 22:10:11
+28,2022-01-27 22:10:11,25,bought something,,{"bought_something": 1},100,,1,2022-02-23 22:10:11
+29,2022-01-28 22:10:11,1,visited page,,{"visited_page": 1},0,,2,
+30,2022-01-29 22:10:11,1,signed up,,{"signed_up": 1},0,,2,
+31,2022-01-30 22:10:11,1,bought something,,{"bought_something": 1},100,,2,
+32,2022-01-31 22:10:11,4,visited page,,{"visited_page": 1},0,,2,
+33,2022-02-01 22:10:11,4,signed up,,{"signed_up": 1},0,,2,
+34,2022-02-02 22:10:11,4,bought something,,{"bought_something": 1},100,,2,
+35,2022-02-03 22:10:11,7,visited page,,{"visited_page": 1},0,,2,
+36,2022-02-04 22:10:11,7,signed up,,{"signed_up": 1},0,,2,
+37,2022-02-05 22:10:11,7,bought something,,{"bought_something": 1},100,,2,
+38,2022-02-06 22:10:11,10,visited page,,{"visited_page": 1},0,,2,
+39,2022-02-07 22:10:11,10,signed up,,{"signed_up": 1},0,,2,
+40,2022-02-08 22:10:11,10,bought something,,{"bought_something": 1},100,,2,
+41,2022-02-09 22:10:11,13,visited page,,{"visited_page": 1},0,,2,
+42,2022-02-10 22:10:11,13,signed up,,{"signed_up": 1},0,,2,
+43,2022-02-11 22:10:11,13,bought something,,{"bought_something": 1},100,,2,
+44,2022-02-12 22:10:11,16,visited page,,{"visited_page": 1},0,,2,
+45,2022-02-13 22:10:11,16,signed up,,{"signed_up": 1},0,,2,
+46,2022-02-14 22:10:11,16,bought something,,{"bought_something": 1},100,,2,
+47,2022-02-15 22:10:11,19,visited page,,{"visited_page": 1},0,,2,
+48,2022-02-16 22:10:11,19,signed up,,{"signed_up": 1},0,,2,
+49,2022-02-17 22:10:11,19,bought something,,{"bought_something": 1},100,,2,
+50,2022-02-18 22:10:11,22,visited page,,{"visited_page": 1},0,,2,
+51,2022-02-19 22:10:11,22,signed up,,{"signed_up": 1},0,,2,
+52,2022-02-20 22:10:11,22,bought something,,{"bought_something": 1},100,,2,
+53,2022-02-21 22:10:11,25,visited page,,{"visited_page": 1},0,,2,
+54,2022-02-22 22:10:11,25,signed up,,{"signed_up": 1},0,,2,
+55,2022-02-23 22:10:11,25,bought something,,{"bought_something": 1},100,,2,

--- a/integration_tests/seeds/first_before/output/output__first_before_1.csv
+++ b/integration_tests/seeds/first_before/output/output__first_before_1.csv
@@ -1,19 +1,19 @@
 activity_id,entity_uuid,ts,activity,anonymous_entity_uuid,feature_json,revenue_impact,link,activity_occurrence,activity_repeated_at,first_before_visited_page_feature_json,first_before_visited_page_ts
-4,1,2022-01-03 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-01-30 22:10:11,"[{""""visited page"""": 1}]",2022-01-01 22:10:11
-7,4,2022-01-06 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-02-02 22:10:11,"[{""""visited page"""": 1}]",2022-01-04 22:10:11
-10,7,2022-01-09 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-02-05 22:10:11,"[{""""visited page"""": 1}]",2022-01-07 22:10:11
-13,10,2022-01-12 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-02-08 22:10:11,"[{""""visited page"""": 1}]",2022-01-10 22:10:11
-16,13,2022-01-15 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-02-11 22:10:11,"[{""""visited page"""": 1}]",2022-01-13 22:10:11
-19,16,2022-01-18 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-02-14 22:10:11,"[{""""visited page"""": 1}]",2022-01-16 22:10:11
-22,19,2022-01-21 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-02-17 22:10:11,"[{""""visited page"""": 1}]",2022-01-19 22:10:11
-25,22,2022-01-24 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-02-20 22:10:11,"[{""""visited page"""": 1}]",2022-01-22 22:10:11
-28,25,2022-01-27 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-02-23 22:10:11,"[{""""visited page"""": 1}]",2022-01-25 22:10:11
-31,1,2022-01-30 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-01-01 22:10:11
-34,4,2022-02-02 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-01-04 22:10:11
-37,7,2022-02-05 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-01-07 22:10:11
-40,10,2022-02-08 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-01-10 22:10:11
-43,13,2022-02-11 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-01-13 22:10:11
-46,16,2022-02-14 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-01-16 22:10:11
-49,19,2022-02-17 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-01-19 22:10:11
-52,22,2022-02-20 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-01-22 22:10:11
-55,25,2022-02-23 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-01-25 22:10:11
+4,1,2022-01-03 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-01-30 22:10:11,{"visited_page": 1},2022-01-01 22:10:11
+7,4,2022-01-06 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-02-02 22:10:11,{"visited_page": 1},2022-01-04 22:10:11
+10,7,2022-01-09 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-02-05 22:10:11,{"visited_page": 1},2022-01-07 22:10:11
+13,10,2022-01-12 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-02-08 22:10:11,{"visited_page": 1},2022-01-10 22:10:11
+16,13,2022-01-15 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-02-11 22:10:11,{"visited_page": 1},2022-01-13 22:10:11
+19,16,2022-01-18 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-02-14 22:10:11,{"visited_page": 1},2022-01-16 22:10:11
+22,19,2022-01-21 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-02-17 22:10:11,{"visited_page": 1},2022-01-19 22:10:11
+25,22,2022-01-24 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-02-20 22:10:11,{"visited_page": 1},2022-01-22 22:10:11
+28,25,2022-01-27 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-02-23 22:10:11,{"visited_page": 1},2022-01-25 22:10:11
+31,1,2022-01-30 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-01-01 22:10:11
+34,4,2022-02-02 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-01-04 22:10:11
+37,7,2022-02-05 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-01-07 22:10:11
+40,10,2022-02-08 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-01-10 22:10:11
+43,13,2022-02-11 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-01-13 22:10:11
+46,16,2022-02-14 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-01-16 22:10:11
+49,19,2022-02-17 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-01-19 22:10:11
+52,22,2022-02-20 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-01-22 22:10:11
+55,25,2022-02-23 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-01-25 22:10:11

--- a/integration_tests/seeds/first_ever/output/output__first_ever_1.csv
+++ b/integration_tests/seeds/first_ever/output/output__first_ever_1.csv
@@ -1,19 +1,19 @@
-﻿activity_id,entity_uuid,ts,activity,anonymous_entity_uuid,feature_json,revenue_impact,link,activity_occurrence,activity_repeated_at,first_ever_signed_up_feature_json,first_ever_signed_up_ts
-2,1,2022-01-01 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,1,2022-01-28 22:10:11,"[{""""signed up"""": 1}]",2022-01-02 22:10:11
-5,4,2022-01-04 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,1,2022-01-31 22:10:11,"[{""""signed up"""": 1}]",2022-01-05 22:10:11
-8,7,2022-01-07 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,1,2022-02-03 22:10:11,"[{""""signed up"""": 1}]",2022-01-08 22:10:11
-11,10,2022-01-10 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,1,2022-02-06 22:10:11,"[{""""signed up"""": 1}]",2022-01-11 22:10:11
-14,13,2022-01-13 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,1,2022-02-09 22:10:11,"[{""""signed up"""": 1}]",2022-01-14 22:10:11
-17,16,2022-01-16 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,1,2022-02-12 22:10:11,"[{""""signed up"""": 1}]",2022-01-17 22:10:11
-20,19,2022-01-19 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,1,2022-02-15 22:10:11,"[{""""signed up"""": 1}]",2022-01-20 22:10:11
-23,22,2022-01-22 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,1,2022-02-18 22:10:11,"[{""""signed up"""": 1}]",2022-01-23 22:10:11
-26,25,2022-01-25 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,1,2022-02-21 22:10:11,"[{""""signed up"""": 1}]",2022-01-26 22:10:11
-29,1,2022-01-28 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""signed up"""": 1}]",2022-01-02 22:10:11
-32,4,2022-01-31 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""signed up"""": 1}]",2022-01-05 22:10:11
-35,7,2022-02-03 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""signed up"""": 1}]",2022-01-08 22:10:11
-38,10,2022-02-06 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""signed up"""": 1}]",2022-01-11 22:10:11
-41,13,2022-02-09 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""signed up"""": 1}]",2022-01-14 22:10:11
-44,16,2022-02-12 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""signed up"""": 1}]",2022-01-17 22:10:11
-47,19,2022-02-15 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""signed up"""": 1}]",2022-01-20 22:10:11
-50,22,2022-02-18 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""signed up"""": 1}]",2022-01-23 22:10:11
-53,25,2022-02-21 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""signed up"""": 1}]",2022-01-26 22:10:11
+﻿activity_id,entity_uuid,ts,activity,anonymous_entity_uuid,feature_json,revenue_impact,link,activity_occurrence,activity_repeated_at,first_ever_signed_up_feature_json,first_ever_signed_up_ts,first_ever_signed_up_signed_up
+2,1,2022-01-01 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-01-28 22:10:11,{"signed_up": 1},2022-01-02 22:10:11,1
+5,4,2022-01-04 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-01-31 22:10:11,{"signed_up": 1},2022-01-05 22:10:11,1
+8,7,2022-01-07 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-02-03 22:10:11,{"signed_up": 1},2022-01-08 22:10:11,1
+11,10,2022-01-10 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-02-06 22:10:11,{"signed_up": 1},2022-01-11 22:10:11,1
+14,13,2022-01-13 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-02-09 22:10:11,{"signed_up": 1},2022-01-14 22:10:11,1
+17,16,2022-01-16 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-02-12 22:10:11,{"signed_up": 1},2022-01-17 22:10:11,1
+20,19,2022-01-19 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-02-15 22:10:11,{"signed_up": 1},2022-01-20 22:10:11,1
+23,22,2022-01-22 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-02-18 22:10:11,{"signed_up": 1},2022-01-23 22:10:11,1
+26,25,2022-01-25 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-02-21 22:10:11,{"signed_up": 1},2022-01-26 22:10:11,1
+29,1,2022-01-28 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-02 22:10:11,1
+32,4,2022-01-31 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-05 22:10:11,1
+35,7,2022-02-03 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-08 22:10:11,1
+38,10,2022-02-06 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-11 22:10:11,1
+41,13,2022-02-09 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-14 22:10:11,1
+44,16,2022-02-12 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-17 22:10:11,1
+47,19,2022-02-15 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-20 22:10:11,1
+50,22,2022-02-18 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-23 22:10:11,1
+53,25,2022-02-21 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-26 22:10:11,1

--- a/integration_tests/seeds/first_ever/output/output__first_ever_1.csv
+++ b/integration_tests/seeds/first_ever/output/output__first_ever_1.csv
@@ -1,19 +1,19 @@
-﻿activity_id,entity_uuid,ts,activity,anonymous_entity_uuid,feature_json,revenue_impact,link,activity_occurrence,activity_repeated_at,first_ever_signed_up_feature_json,first_ever_signed_up_ts,first_ever_signed_up_signed_up
-2,1,2022-01-01 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-01-28 22:10:11,{"signed_up": 1},2022-01-02 22:10:11,1
-5,4,2022-01-04 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-01-31 22:10:11,{"signed_up": 1},2022-01-05 22:10:11,1
-8,7,2022-01-07 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-02-03 22:10:11,{"signed_up": 1},2022-01-08 22:10:11,1
-11,10,2022-01-10 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-02-06 22:10:11,{"signed_up": 1},2022-01-11 22:10:11,1
-14,13,2022-01-13 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-02-09 22:10:11,{"signed_up": 1},2022-01-14 22:10:11,1
-17,16,2022-01-16 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-02-12 22:10:11,{"signed_up": 1},2022-01-17 22:10:11,1
-20,19,2022-01-19 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-02-15 22:10:11,{"signed_up": 1},2022-01-20 22:10:11,1
-23,22,2022-01-22 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-02-18 22:10:11,{"signed_up": 1},2022-01-23 22:10:11,1
-26,25,2022-01-25 22:10:11,visited page,,{"visited_page": 1},0,,1,2022-02-21 22:10:11,{"signed_up": 1},2022-01-26 22:10:11,1
-29,1,2022-01-28 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-02 22:10:11,1
-32,4,2022-01-31 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-05 22:10:11,1
-35,7,2022-02-03 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-08 22:10:11,1
-38,10,2022-02-06 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-11 22:10:11,1
-41,13,2022-02-09 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-14 22:10:11,1
-44,16,2022-02-12 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-17 22:10:11,1
-47,19,2022-02-15 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-20 22:10:11,1
-50,22,2022-02-18 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-23 22:10:11,1
-53,25,2022-02-21 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"signed_up": 1},2022-01-26 22:10:11,1
+﻿activity_id,entity_uuid,ts,activity,anonymous_entity_uuid,feature_json,revenue_impact,visited_page,link,activity_occurrence,activity_repeated_at,first_ever_signed_up_feature_json,first_ever_signed_up_ts,first_ever_signed_up_signed_up
+2,1,2022-01-01 22:10:11,visited page,,{"visited_page": 1},0,1,,1,2022-01-28 22:10:11,{"signed_up": 1},2022-01-02 22:10:11,1
+5,4,2022-01-04 22:10:11,visited page,,{"visited_page": 1},0,1,,1,2022-01-31 22:10:11,{"signed_up": 1},2022-01-05 22:10:11,1
+8,7,2022-01-07 22:10:11,visited page,,{"visited_page": 1},0,1,,1,2022-02-03 22:10:11,{"signed_up": 1},2022-01-08 22:10:11,1
+11,10,2022-01-10 22:10:11,visited page,,{"visited_page": 1},0,1,,1,2022-02-06 22:10:11,{"signed_up": 1},2022-01-11 22:10:11,1
+14,13,2022-01-13 22:10:11,visited page,,{"visited_page": 1},0,1,,1,2022-02-09 22:10:11,{"signed_up": 1},2022-01-14 22:10:11,1
+17,16,2022-01-16 22:10:11,visited page,,{"visited_page": 1},0,1,,1,2022-02-12 22:10:11,{"signed_up": 1},2022-01-17 22:10:11,1
+20,19,2022-01-19 22:10:11,visited page,,{"visited_page": 1},0,1,,1,2022-02-15 22:10:11,{"signed_up": 1},2022-01-20 22:10:11,1
+23,22,2022-01-22 22:10:11,visited page,,{"visited_page": 1},0,1,,1,2022-02-18 22:10:11,{"signed_up": 1},2022-01-23 22:10:11,1
+26,25,2022-01-25 22:10:11,visited page,,{"visited_page": 1},0,1,,1,2022-02-21 22:10:11,{"signed_up": 1},2022-01-26 22:10:11,1
+29,1,2022-01-28 22:10:11,visited page,,{"visited_page": 1},0,1,,2,,{"signed_up": 1},2022-01-02 22:10:11,1
+32,4,2022-01-31 22:10:11,visited page,,{"visited_page": 1},0,1,,2,,{"signed_up": 1},2022-01-05 22:10:11,1
+35,7,2022-02-03 22:10:11,visited page,,{"visited_page": 1},0,1,,2,,{"signed_up": 1},2022-01-08 22:10:11,1
+38,10,2022-02-06 22:10:11,visited page,,{"visited_page": 1},0,1,,2,,{"signed_up": 1},2022-01-11 22:10:11,1
+41,13,2022-02-09 22:10:11,visited page,,{"visited_page": 1},0,1,,2,,{"signed_up": 1},2022-01-14 22:10:11,1
+44,16,2022-02-12 22:10:11,visited page,,{"visited_page": 1},0,1,,2,,{"signed_up": 1},2022-01-17 22:10:11,1
+47,19,2022-02-15 22:10:11,visited page,,{"visited_page": 1},0,1,,2,,{"signed_up": 1},2022-01-20 22:10:11,1
+50,22,2022-02-18 22:10:11,visited page,,{"visited_page": 1},0,1,,2,,{"signed_up": 1},2022-01-23 22:10:11,1
+53,25,2022-02-21 22:10:11,visited page,,{"visited_page": 1},0,1,,2,,{"signed_up": 1},2022-01-26 22:10:11,1

--- a/integration_tests/seeds/last_before/output/output__last_before_1.csv
+++ b/integration_tests/seeds/last_before/output/output__last_before_1.csv
@@ -1,19 +1,19 @@
 activity_id,entity_uuid,ts,activity,anonymous_entity_uuid,feature_json,revenue_impact,link,activity_occurrence,activity_repeated_at,last_before_visited_page_feature_json,last_before_visited_page_ts
-31,1,2022-01-30 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-01-28 22:10:11
-34,4,2022-02-02 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-01-31 22:10:11
-37,7,2022-02-05 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-02-03 22:10:11
-40,10,2022-02-08 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-02-06 22:10:11
-43,13,2022-02-11 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-02-09 22:10:11
-46,16,2022-02-14 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-02-12 22:10:11
-49,19,2022-02-17 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-02-15 22:10:11
-52,22,2022-02-20 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-02-18 22:10:11
-55,25,2022-02-23 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,2,,"[{""""visited page"""": 1}]",2022-02-21 22:10:11
-4,1,2022-01-03 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-01-30 22:10:11,"[{""""visited page"""": 1}]",2022-01-01 22:10:11
-7,4,2022-01-06 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-02-02 22:10:11,"[{""""visited page"""": 1}]",2022-01-04 22:10:11
-10,7,2022-01-09 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-02-05 22:10:11,"[{""""visited page"""": 1}]",2022-01-07 22:10:11
-13,10,2022-01-12 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-02-08 22:10:11,"[{""""visited page"""": 1}]",2022-01-10 22:10:11
-16,13,2022-01-15 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-02-11 22:10:11,"[{""""visited page"""": 1}]",2022-01-13 22:10:11
-19,16,2022-01-18 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-02-14 22:10:11,"[{""""visited page"""": 1}]",2022-01-16 22:10:11
-22,19,2022-01-21 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-02-17 22:10:11,"[{""""visited page"""": 1}]",2022-01-19 22:10:11
-25,22,2022-01-24 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-02-20 22:10:11,"[{""""visited page"""": 1}]",2022-01-22 22:10:11
-28,25,2022-01-27 22:10:11,bought something,,"[{""""bought something"""": 1}]",100,,1,2022-02-23 22:10:11,"[{""""visited page"""": 1}]",2022-01-25 22:10:11
+31,1,2022-01-30 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-01-28 22:10:11
+34,4,2022-02-02 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-01-31 22:10:11
+37,7,2022-02-05 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-02-03 22:10:11
+40,10,2022-02-08 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-02-06 22:10:11
+43,13,2022-02-11 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-02-09 22:10:11
+46,16,2022-02-14 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-02-12 22:10:11
+49,19,2022-02-17 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-02-15 22:10:11
+52,22,2022-02-20 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-02-18 22:10:11
+55,25,2022-02-23 22:10:11,bought something,,{"bought_something": 1},100,,2,,{"visited_page": 1},2022-02-21 22:10:11
+4,1,2022-01-03 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-01-30 22:10:11,{"visited_page": 1},2022-01-01 22:10:11
+7,4,2022-01-06 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-02-02 22:10:11,{"visited_page": 1},2022-01-04 22:10:11
+10,7,2022-01-09 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-02-05 22:10:11,{"visited_page": 1},2022-01-07 22:10:11
+13,10,2022-01-12 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-02-08 22:10:11,{"visited_page": 1},2022-01-10 22:10:11
+16,13,2022-01-15 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-02-11 22:10:11,{"visited_page": 1},2022-01-13 22:10:11
+19,16,2022-01-18 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-02-14 22:10:11,{"visited_page": 1},2022-01-16 22:10:11
+22,19,2022-01-21 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-02-17 22:10:11,{"visited_page": 1},2022-01-19 22:10:11
+25,22,2022-01-24 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-02-20 22:10:11,{"visited_page": 1},2022-01-22 22:10:11
+28,25,2022-01-27 22:10:11,bought something,,{"bought_something": 1},100,,1,2022-02-23 22:10:11,{"visited_page": 1},2022-01-25 22:10:11

--- a/integration_tests/seeds/last_ever/output/output__last_ever_1.csv
+++ b/integration_tests/seeds/last_ever/output/output__last_ever_1.csv
@@ -1,10 +1,10 @@
 activity_id,entity_uuid,ts,activity,anonymous_entity_uuid,feature_json,revenue_impact,link,activity_occurrence,activity_repeated_at,last_ever_bought_something_feature_json,last_ever_bought_something_ts
-29,1,2022-01-28 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""bought something"""": 1}]",2022-01-30 22:10:11
-32,4,2022-01-31 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""bought something"""": 1}]",2022-02-02 22:10:11
-35,7,2022-02-03 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""bought something"""": 1}]",2022-02-05 22:10:11
-38,10,2022-02-06 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""bought something"""": 1}]",2022-02-08 22:10:11
-41,13,2022-02-09 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""bought something"""": 1}]",2022-02-11 22:10:11
-44,16,2022-02-12 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""bought something"""": 1}]",2022-02-14 22:10:11
-47,19,2022-02-15 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""bought something"""": 1}]",2022-02-17 22:10:11
-50,22,2022-02-18 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""bought something"""": 1}]",2022-02-20 22:10:11
-53,25,2022-02-21 22:10:11,visited page,,"[{""""visited page"""": 1}]",0,,2,,"[{""""bought something"""": 1}]",2022-02-23 22:10:11
+29,1,2022-01-28 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"bought_something": 1},2022-01-30 22:10:11
+32,4,2022-01-31 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"bought_something": 1},2022-02-02 22:10:11
+35,7,2022-02-03 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"bought_something": 1},2022-02-05 22:10:11
+38,10,2022-02-06 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"bought_something": 1},2022-02-08 22:10:11
+41,13,2022-02-09 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"bought_something": 1},2022-02-11 22:10:11
+44,16,2022-02-12 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"bought_something": 1},2022-02-14 22:10:11
+47,19,2022-02-15 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"bought_something": 1},2022-02-17 22:10:11
+50,22,2022-02-18 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"bought_something": 1},2022-02-20 22:10:11
+53,25,2022-02-21 22:10:11,visited page,,{"visited_page": 1},0,,2,,{"bought_something": 1},2022-02-23 22:10:11

--- a/macros/dataset.sql
+++ b/macros/dataset.sql
@@ -42,7 +42,7 @@ with
 filter_activity_stream_using_primary_activity as (
     select
         {% for col in primary_activity.included_columns + primary_activity.required_columns %}
-        {{ primary() }}.{{ col }}{%- if not loop.last -%},{%- endif %}
+        {{ dbt_activity_schema.parse_column(primary(), col) }} as {{ col }}{%- if not loop.last -%},{%- endif %}
         {% endfor %}
 
     from {{ activity_stream }} as {{ primary() }}
@@ -62,11 +62,7 @@ filter_activity_stream_using_primary_activity as (
         {% endfor %}
 
         {% for col in activity.included_columns %}
-            {%- if col not in columns.values() -%}
-                {%- set parsed_col = dbt_activity_schema.json_unpack_key(appended() ~ '.' ~ columns.feature_json, col) -%}
-            {%- else -%}
-                {%- set parsed_col = appended() ~ '.' ~ col -%}
-            {%- endif -%}
+            {%- set parsed_col = dbt_activity_schema.parse_column(appended(), col) -%}
             {% call activity.relationship.aggregation_func() %}
             {{ parsed_col }}
             {% endcall %} as {{ dbt_activity_schema.alias_appended_activity(activity, col) }}

--- a/macros/dataset.sql
+++ b/macros/dataset.sql
@@ -62,8 +62,13 @@ filter_activity_stream_using_primary_activity as (
         {% endfor %}
 
         {% for col in activity.included_columns %}
+            {%- if col not in columns.values() -%}
+                {%- set parsed_col = dbt_activity_schema.json_unpack_key(appended() ~ '.' ~ columns.feature_json, col) -%}
+            {%- else -%}
+                {%- set parsed_col = appended() ~ '.' ~ col -%}
+            {%- endif -%}
             {% call activity.relationship.aggregation_func() %}
-            {{ appended() }}.{{ col }}
+            {{ parsed_col }}
             {% endcall %} as {{ dbt_activity_schema.alias_appended_activity(activity, col) }}
             {% if not loop.last %},{% endif %}
         {% endfor %}

--- a/macros/utils/helpers/parse_column.sql
+++ b/macros/utils/helpers/parse_column.sql
@@ -1,0 +1,11 @@
+{% macro parse_column(table_alias, column) %}
+
+{% set columns = dbt_activity_schema.columns() %}
+{%- if column not in columns.values() -%}
+    {%- set parsed_column = dbt_activity_schema.json_unpack_key(table_alias ~ '.' ~ columns.feature_json, column) -%}
+{%- else -%}
+    {%- set parsed_column = table_alias ~ '.' ~ column -%}
+{%- endif -%}
+
+{% do return(parsed_column) %}
+{% endmacro %}


### PR DESCRIPTION
This PR:
* adds a function called `parse_column` which returns `table_alias.column` and extracts the column from the activity stream's `feature_json` column if the column name is not identified as a standard column from the Activity Schema, then applies that function to all columns selected from all primary and appended columns in the `dataset` macro
* updates an existing test (`first_ever_1`) to extract json features from the primary and appended activity
* updates `example__activity_stream` and relevant `output__<dataset>` csv files so that `feature_json` values aren't nested in an array and so that `feature_json` keys use snake case formatting
* updates documentation for the `included_columns` argument in the Readme
