### PR TITLE
Improve readability of compiled dataset SQL (Fixes #30)

### DIFF
--- a/macros/activity.sql
+++ b/macros/activity.sql
@@ -1,18 +1,15 @@
 {% macro activity(
     relationship,
     activity_name,
-    included_columns=var("included_columns", var("dbt_activity_schema",
-    {}).get("included_columns", dbt_activity_schema.columns().values() | list)),
+    included_columns=var("included_columns", var("dbt_activity_schema", {}).get("included_columns", dbt_activity_schema.columns().values() | list)),
     additional_join_condition="true"
 ) %}
-
-{{ return(adapter.dispatch("activity", "dbt_activity_schema")(
-    relationship,
-    activity_name,
-    included_columns,
-    additional_join_condition
-)) }}
-
+    {{ return(adapter.dispatch("activity", "dbt_activity_schema")(
+        relationship,
+        activity_name,
+        included_columns,
+        additional_join_condition
+    )) }}
 {% endmacro %}
 
 {% macro default__activity(
@@ -21,72 +18,34 @@
     included_columns,
     additional_join_condition
 ) %}
+    {# Macro for defining a single activity in the dataset. #}
 
-{# An activity to include in the dataset.
+    {# Column mapping from utility macro #}
+    {% set columns = dbt_activity_schema.columns() %}
 
-params:
+    {# Required columns for join integrity #}
+    {% set required_columns = [
+        columns.activity_id,
+        columns.activity,
+        columns.ts,
+        columns.customer,
+        columns.activity_occurrence,
+        columns.activity_repeated_at
+    ] %}
 
-    relationship: relationship
-        The relationship that defines the how the appended activity is joined to
-        the primary activity.
+    {# Remove any already included columns from required_columns #}
+    {% for col in included_columns %}
+        {% if col in required_columns %}
+            {% do required_columns.remove(col) %}
+        {% endif %}
+    {% endfor %}
 
-    activity_name: str
-        The string identifier of the activity in the Activity Stream to join to
-        the primary activity.
-
-    included_columns: List[str]
-        List of columns to join to the primary activity, defaults to the
-        `included_columns` vars if it is set, otherwise defaults to the columns
-        defined in columns.sql.
-
-    additional_join_condition: str
-        A valid sql boolean to condition the join of the appended activity. Can
-        optionally contain the python f-string placeholders "{primary}" and
-        "{appended}" in the string; these will be compiled with the correct
-        aliases.
-
-        Eg:
-
-        "json_extract({primary}.feature_json, 'dim1')
-            = "json_extract({appended}.feature_json, 'dim1')"
-
-        The "{primary}" and "{appended}" placholders correctly compiled
-        depending on the cardinatity of the joined activity in the
-        `appended_activities` list argument to `dataset.sql`.
-
-        Compiled:
-
-        "json_extract(stream.feature_json, 'dim1')
-            = "json_extract(stream_3.feature_json, 'dim1')"
-
-        Given that the appended activity was 3rd in the `appended_activities`
-        list argument.
-#}
-
-{% set columns = dbt_activity_schema.columns() %}
-
-{# Required for the joins, but not necessarily included in the final result. #}
-{% set required_columns = [
-    columns.activity_id,
-    columns.activity,
-    columns.ts,
-    columns.customer,
-    columns.activity_occurrence,
-    columns.activity_repeated_at
-] %}
-
-{% for col in included_columns %}
-    {% if col in required_columns %}
-        {% do required_columns.remove(col) %}
-    {% endif %}
-{% endfor %}
-
-{% do return(namespace(
-    name = activity_name,
-    included_columns = included_columns,
-    required_columns = required_columns,
-    relationship = relationship,
-    additional_join_condition = additional_join_condition
-)) %}
-
+    {# Return a namespace containing all necessary metadata #}
+    {% do return(namespace(
+        name = activity_name,
+        included_columns = included_columns,
+        required_columns = required_columns,
+        relationship = relationship,
+        additional_join_condition = additional_join_condition
+    )) %}
 {% endmacro %}

--- a/macros/dataset.sql
+++ b/macros/dataset.sql
@@ -1,32 +1,8 @@
-{% macro dataset(
-    activity_stream,
-    primary_activity,
-    appended_activities=[]
-) %} {{ return(adapter.dispatch("dataset", "dbt_activity_schema")(
-    activity_stream,
-    primary_activity,
-    appended_activities
-)) }} {% endmacro %}
+{% macro dataset(activity_stream, primary_activity, appended_activities=[]) %}
+  {{ return(adapter.dispatch("dataset", "dbt_activity_schema")(activity_stream, primary_activity, appended_activities)) }}
+{% endmacro %}
 
-{% macro default__dataset(
-    activity_stream,
-    primary_activity,
-    appended_activities
-) %}
-
-{# Create a derived dataset using self-joins from an Activity Stream model.
-
-params:
-
-    activity_stream: ref() | str
-        The dbt `ref()` or a CTE name that contains the required columns.
-
-    primary_activity: activity (class)
-        The primary activity of the derived dataset.
-
-    appended_activities: List[ activity (class) ]
-        The list of appended activities to self-join to the primary activity.
-#}
+{% macro default__dataset(activity_stream, primary_activity, appended_activities) %}
 
 {% set columns = dbt_activity_schema.columns() %}
 {% set primary = dbt_activity_schema.primary %}
@@ -42,85 +18,71 @@ with
 filter_activity_stream_using_primary_activity as (
     select
         {% for col in primary_activity.included_columns + primary_activity.required_columns %}
-        {{ dbt_activity_schema.parse_column(primary(), col) }} as {{ col }}{%- if not loop.last -%},{%- endif %}
+        {{ dbt_activity_schema.parse_column(primary(), col) }} as {{ col }}{% if not loop.last %},{% endif %}
         {% endfor %}
 
     from {{ activity_stream }} as {{ primary() }}
-
     where {{ primary() }}.{{ columns.activity }} = {{ dbt.string_literal(primary_activity.name) }}
-        and {{ primary_activity.relationship.where_clause }}
+      and {{ primary_activity.relationship.where_clause }}
 ),
 
-{% for activity in appended_activities %}{% set i = loop.index %}
-
+{% for activity in appended_activities %}
+{% set i = loop.index %}
 {{ alias_cte(activity, i) }} as (
     select
-
-        -- Primary Activity Columns
         {% for col in primary_activity.included_columns + primary_activity.required_columns %}
-        {{ primary() }}.{{- col }},
-        {% endfor %}
+        {{ primary() }}.{{ col }},{% endfor %}
 
         {% for col in activity.included_columns %}
-            {%- set parsed_col = dbt_activity_schema.parse_column(appended(), col) -%}
-            {% call activity.relationship.aggregation_func() %}
-            {{ parsed_col }}
-            {% endcall %} as {{ dbt_activity_schema.alias_appended_activity(activity, col) }}
-            {% if not loop.last %},{% endif %}
+        {% set parsed_col = dbt_activity_schema.parse_column(appended(), col) %}
+        {% call activity.relationship.aggregation_func() %}
+        {{ parsed_col }}
+        {% endcall %} as {{ alias_appended_activity(activity, col) }}{% if not loop.last %},{% endif %}
         {% endfor %}
 
     from filter_activity_stream_using_primary_activity as {{ primary() }}
 
     left join {{ activity_stream }} as {{ appended() }}
-        on (
-            -- Join on Customer UUID Column
-            {{ appended() }}.{{ columns.customer }} = {{ primary() }}.{{ columns.customer }}
-
-            -- Join the Correct Activity
-            and {{ appended() }}.{{- columns.activity }} = {{ dbt.string_literal(activity.name) }}
-
-            -- Relationship Specific Join Conditions
-            and (
-            {# nth_ever_join_clause relies on instantiated nth_occurance arg, in
-            addition to the i passed to the join #}
-            {% if activity.relationship.name == "nth_ever" %}
+      on (
+        {{ appended() }}.{{ columns.customer }} = {{ primary() }}.{{ columns.customer }}
+        and {{ appended() }}.{{ columns.activity }} = {{ dbt.string_literal(activity.name) }}
+        and (
+          {% if activity.relationship.name == "nth_ever" %}
             {{ activity.relationship.join_clause(activity.relationship.nth_occurance) }}
-            {% else %}
+          {% else %}
             {{ activity.relationship.join_clause() }}
-            {% endif %}
-            )
-            -- Additional Join Condition
-            and ( {{ activity.additional_join_condition }} )
+          {% endif %}
         )
+        and ({{ activity.additional_join_condition }})
+      )
 
     group by
-        {% for col in primary_activity.included_columns + primary_activity.required_columns %}
-        {{ primary() }}.{{ col }}{%- if not loop.last -%},{%- endif %}
-        {% endfor %}
+      {% for col in primary_activity.included_columns + primary_activity.required_columns %}
+      {{ primary() }}.{{ col }}{% if not loop.last %},{% endif %}
+      {% endfor %}
 ),
-
 {% endfor %}
 
 rejoin_aggregated_activities as (
     select
+      {% for col in primary_activity.included_columns %}
+      {{ primary() }}.{{ col }}{% if not loop.last or appended_activities %},{% endif %}
+      {% endfor %}
 
-        {% for col in primary_activity.included_columns %}
-        {{ primary() }}.{{ col }},
-        {% endfor %}
-
-        {% for activity in appended_activities %}{% set i = loop.index %}{% set last_outer_loop = loop.last %}
-            {% for col in activity.included_columns %}
-        {{ alias_cte(activity, i) }}.{{ alias_appended_activity(activity, col) }}{% if not (last_outer_loop and loop.last) %},{% endif %}
-            {% endfor %}
-        {% endfor %}
+      {% for activity in appended_activities %}
+      {% set i = loop.index %}
+      {% set last_outer_loop = loop.last %}
+      {% for col in activity.included_columns %}
+      {{ alias_cte(activity, i) }}.{{ alias_appended_activity(activity, col) }}{% if not (last_outer_loop and loop.last) %},{% endif %}
+      {% endfor %}
+      {% endfor %}
 
     from filter_activity_stream_using_primary_activity as {{ primary() }}
 
-    {% for activity in appended_activities %}{% set i = loop.index %}
-
+    {% for activity in appended_activities %}
+    {% set i = loop.index %}
     left join {{ alias_cte(activity, i) }}
-        on {{ alias_cte(activity, i) }}.{{ columns.activity_id }} = {{ primary() }}.{{ columns.activity_id }}
-
+      on {{ alias_cte(activity, i) }}.{{ columns.activity_id }} = {{ primary() }}.{{ columns.activity_id }}
     {% endfor %}
 )
 


### PR DESCRIPTION
This PR addresses Issue #30 by removing unnecessary whitespace and Jinja-related line breaks in macros. The goal is to make the compiled SQL easier to read for both developers and users. 

Changes include:
- Cleaned up macros in `datasets/`, `activity/`, etc.
- Removed redundant newlines
- Preserved logic and structure while improving visual clarity of compiled output

Let me know if any further adjustments are needed!
